### PR TITLE
fix(docs): Fixed typo

### DIFF
--- a/eq2-docs/src/content/docs/standards/canbus.mdx
+++ b/eq2-docs/src/content/docs/standards/canbus.mdx
@@ -3,8 +3,9 @@ title: CANBus Standards
 description: CANBus Standards for Equinox 2
 ---
 
-CAN Standards v3.0.1
-CANBus messages will not have responses, only reuests.
+**<u>CAN Standards v3.0.1</u>**
+
+CANBus messages will not have responses, only requests.
 ## CAN Bus Standards
 ### Header
 The header specifies three key segments:


### PR DESCRIPTION
Fixed typo in CAN Bus standard. Missed the q in request. Oops!
<img width="738" height="369" alt="anime-oops" src="https://github.com/user-attachments/assets/963eac6e-61a5-4adb-a26d-5d149db5cc2f" />
#91