### PR TITLE
Feat/gimbal hardware interface (#101)

### DIFF
--- a/onboard/hardware-interfaces/gimbal/GimbalServo.cpp
+++ b/onboard/hardware-interfaces/gimbal/GimbalServo.cpp
@@ -1,0 +1,1 @@
+#include "GimbalServo.h" 

--- a/onboard/hardware-interfaces/gimbal/GimbalServo.cpp
+++ b/onboard/hardware-interfaces/gimbal/GimbalServo.cpp
@@ -1,1 +1,24 @@
-#include "GimbalServo.h" 
+#include "GimbalServo.h"
+
+GimbalServo::GimbalServo(uint8_t device_id, RoverCanMaster &can_master) : device_id(device_id), can_master(can_master), tilt_speed(0.0), pan_position(0.0) {}
+
+void GimbalServo::set_gimbal_movement(int8_t target_tilt_speed, int8_t target_pan_position) {
+    spdlog::critical("Set gimbal servo {0:x} tilt speed to {1:d} and pan position to {2:d}", device_id, target_tilt_speed, target_pan_position);
+
+    tilt_speed = target_tilt_speed;
+    pan_position = target_pan_position;
+
+    int8_t msg[8] = { tilt_speed, pan_position, 0, 0, 0, 0, 0, 0 };
+    can_master.tx_int8(GroupId::ONBOARD, device_id, msg);
+}
+
+void GimbalServo::estop() {
+    spdlog::critical("ESTOP GIMBAL SERVO {0:x}", device_id);
+
+    tilt_speed = 0.0;
+    pan_position = 0.0;
+    
+    can_master.estop(GroupId::ONBOARD, device_id);
+}
+
+GimbalServo::~GimbalServo() {}

--- a/onboard/hardware-interfaces/gimbal/GimbalServo.cpp
+++ b/onboard/hardware-interfaces/gimbal/GimbalServo.cpp
@@ -1,6 +1,14 @@
 #include "GimbalServo.h"
 
-GimbalServo::GimbalServo(uint8_t device_id, RoverCanMaster &can_master) : device_id(device_id), can_master(can_master), tilt_speed(0.0), pan_position(0.0) {}
+GimbalServo::GimbalServo(uint8_t device_id, RoverCanMaster &can_master) 
+    : device_id(device_id)
+    , can_master(can_master)
+    , tilt_speed(0.0)
+    , pan_position(0.0) {}
+
+GimbalServo::~GimbalServo() {
+
+}
 
 void GimbalServo::set_gimbal_movement(int8_t target_tilt_speed, int8_t target_pan_position) {
     spdlog::critical("Set gimbal servo {0:x} tilt speed to {1:d} and pan position to {2:d}", device_id, target_tilt_speed, target_pan_position);
@@ -20,5 +28,3 @@ void GimbalServo::estop() {
     
     can_master.estop(GroupId::ONBOARD, device_id);
 }
-
-GimbalServo::~GimbalServo() {}

--- a/onboard/hardware-interfaces/gimbal/GimbalServo.h
+++ b/onboard/hardware-interfaces/gimbal/GimbalServo.h
@@ -4,11 +4,13 @@
 #include "../lib-universal-canbus/libuniversalcan/RoverCanMaster.h"
 #include "spdlog/spdlog.h"
 
+// Controls the gimbal servo via CAN bus
+// Handles tilt speed and pan position for camera movement
 class GimbalServo {
 private:
-    uint8_t device_id;
-    int8_t tilt_speed;
-    int8_t pan_position;
+    uint8_t device_id;     // unique servo device id on the CAN bus
+    int8_t tilt_speed;     // current tilt speed (-128 to 127)
+    int8_t pan_position;   // current pan position (-128 to 127)
     RoverCanMaster &can_master; // can only have 1 master per bus, so use a ptr
 
 public:

--- a/onboard/hardware-interfaces/gimbal/GimbalServo.h
+++ b/onboard/hardware-interfaces/gimbal/GimbalServo.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <stdint.h>
+#include "../GenericCan.h"
+#include "../lib-universal-canbus/libuniversalcan/RoverCanMaster.h"
+
+class GimbalServo {
+private:
+    uint8_t device_id;
+    int16_t tiltSpeed;
+    int16_t panSpeed;
+    RoverCanMaster &can_master; // can only have 1 master per bus, so use a ptr
+
+public:
+    GimbalServo(uint8_t device_id, RoverCanMaster &can_master);
+    ~GimbalServo();
+    void set_tilt_speed(int16_t target_tilt_speed);
+    void set_pan_speed(int16_t target_pan_speed);
+    void estop();
+};

--- a/onboard/hardware-interfaces/gimbal/GimbalServo.h
+++ b/onboard/hardware-interfaces/gimbal/GimbalServo.h
@@ -2,18 +2,18 @@
 #include <stdint.h>
 #include "../GenericCan.h"
 #include "../lib-universal-canbus/libuniversalcan/RoverCanMaster.h"
+#include "spdlog/spdlog.h"
 
 class GimbalServo {
 private:
     uint8_t device_id;
-    int16_t tiltSpeed;
-    int16_t panSpeed;
+    int8_t tilt_speed;
+    int8_t pan_position;
     RoverCanMaster &can_master; // can only have 1 master per bus, so use a ptr
 
 public:
     GimbalServo(uint8_t device_id, RoverCanMaster &can_master);
     ~GimbalServo();
-    void set_tilt_speed(int16_t target_tilt_speed);
-    void set_pan_speed(int16_t target_pan_speed);
+    void set_gimbal_movement(int8_t target_tilt_speed, int8_t target_pan_position);
     void estop();
 };


### PR DESCRIPTION
Implemented gimbal hardware interface:
- set_gimbal_movement (tilt speed and pan position)
- estop

DeviceIDs for gimbal not known at this stage; needs to be confirmed.

Needs testing (e.g. test cases) to confirm validity.